### PR TITLE
Replace IMAGE_REPOSITORY with DOCKERHUB_USERNAME + APPLICATION_NAME

### DIFF
--- a/.github/scripts/deployment/config.mjs
+++ b/.github/scripts/deployment/config.mjs
@@ -3,7 +3,7 @@
 /**
  * @typedef {Object} ConfigValues
  * @property {string} APPLICATION_NAME
- * @property {string} IMAGE_REPOSITORY
+ * @property {string} DOCKERHUB_USERNAME
  */
 
 /**
@@ -12,11 +12,11 @@
  */
 
 /**
- * @returns {{ applicationName: string, imageRepository: string }}
+ * @returns {{ applicationName: string, dockerhubUsername: string }}
  */
 function validateApplicationConfig() {
   /** @type {Array<keyof ConfigValues>} */
-  const requiredEnvVars = ["APPLICATION_NAME", "IMAGE_REPOSITORY"];
+  const requiredEnvVars = ["APPLICATION_NAME", "DOCKERHUB_USERNAME"];
 
   /** @type {ConfigValues} */
   const envVars = /** @type {any} */ (process.env);
@@ -33,7 +33,7 @@ function validateApplicationConfig() {
 
   return {
     applicationName: envVars.APPLICATION_NAME,
-    imageRepository: envVars.IMAGE_REPOSITORY,
+    dockerhubUsername: envVars.DOCKERHUB_USERNAME,
   };
 }
 
@@ -44,7 +44,7 @@ function validateApplicationConfig() {
  */
 export default async function generateConfig({ context, core }) {
   try {
-    const { applicationName, imageRepository } = validateApplicationConfig();
+    const { applicationName, dockerhubUsername } = validateApplicationConfig();
 
     const isTag = context.ref.startsWith("refs/tags/");
     const tag = isTag ? context.ref.replace("refs/tags/", "") : undefined;
@@ -55,7 +55,7 @@ export default async function generateConfig({ context, core }) {
         ? "production"
         : `pr-${context.payload.pull_request.number}`,
       is_production: isTag ? "true" : "false",
-      image: `${imageRepository}:${isTag ? tag : context.sha}`,
+      image: `${dockerhubUsername}/${applicationName}:${isTag ? tag : context.sha}`,
       hostname: isTag
         ? process.env.BASE_DOMAIN
         : `${context.sha}.${process.env.BASE_DOMAIN}`,

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
           APPLICATION_NAME: ${{ vars.APPLICATION_NAME }}
-          IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         with:
           script: |
             const { default: generateConfig } = await import('${{ github.workspace }}/infrastructure/.github/scripts/deployment/config.mjs');


### PR DESCRIPTION
## Summary

- Removes the per-repo `IMAGE_REPOSITORY` variable
- Docker image path is now derived from the org-wide `DOCKERHUB_USERNAME` secret and the app's `APPLICATION_NAME` variable
- Full image tag format: `<DOCKERHUB_USERNAME>/<APPLICATION_NAME>:<tag>`

## Migration

In consuming repos, remove the `IMAGE_REPOSITORY` variable — no new variable needed since `DOCKERHUB_USERNAME` is already an org-level secret.

## Test plan

- [ ] Verify the `configure` job outputs the correct `image` value in a PR deployment
- [ ] Verify production tag deployment produces the correct image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)