### PR TITLE
feat: self-hosted LiveKit SFU for voice calls

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -67,3 +67,13 @@ jobs:
           tofu init
           tofu apply -input=false -auto-approve
 
+      - name: OpenTofu Apply LiveKit
+        working-directory: ./4-livekit
+        env:
+          TF_VAR_base_domain: ${{ vars.BASE_DOMAIN }}
+          TF_VAR_api_key: ${{ secrets.LIVEKIT_API_KEY }}
+          TF_VAR_api_secret: ${{ secrets.LIVEKIT_API_SECRET }}
+        run: |
+          tofu init
+          tofu apply -input=false -auto-approve
+

--- a/4-livekit/README.md
+++ b/4-livekit/README.md
@@ -1,0 +1,50 @@
+# 4-livekit
+
+Self-hosted [LiveKit](https://livekit.io) SFU for 1:1 voice calls (used by the
+`relay` app). Because LiveKit is an SFU, **all media flows through the server —
+calls are never peer-to-peer**, which satisfies the "all traffic via the server"
+requirement.
+
+## What it deploys
+
+- `livekit` namespace
+- A `livekit-server` Deployment (single replica)
+- Config (incl. API key/secret) as a Secret mounted at `/etc/livekit`
+- `livekit-signaling` ClusterIP + traefik Ingress + cert-manager Certificate →
+  **`wss://livekit.<BASE_DOMAIN>`** (the signaling URL clients connect to)
+- `livekit-media` LoadBalancer (MetalLB) exposing the RTC ports:
+  - TCP `7881` and UDP `7882` (single muxed ports)
+
+## Required configuration
+
+Set on the `Rutger505-Org` (or repo) **Actions secrets**:
+
+- `LIVEKIT_API_KEY`
+- `LIVEKIT_API_SECRET`
+
+And the existing `BASE_DOMAIN` variable is reused for the host.
+
+## Network requirements (must be done by hand)
+
+LiveKit media is real-time WebRTC and cannot be proxied by traefik:
+
+1. **DNS:** point `livekit.<BASE_DOMAIN>` at the traefik LoadBalancer IP (for
+   the `wss` signaling), same as other apps.
+2. **RTC reachability:** the `livekit-media` LoadBalancer gets its own MetalLB
+   IP. For internet clients, port-forward **TCP 7881** and **UDP 7882** on the
+   router to that IP. `rtc.use_external_ip` lets LiveKit advertise the public
+   IP it discovers; verify it matches your forwarded address.
+3. Verify with two real browsers before relying on it — media networking is
+   environment-specific and is not checked by CI.
+
+## Wiring the app
+
+In the `relay` repo, set these `DEPLOYMENT_`-prefixed values so they reach the
+app as env vars:
+
+- `DEPLOYMENT_LIVEKIT_URL = wss://livekit.<BASE_DOMAIN>`
+- `DEPLOYMENT_LIVEKIT_API_KEY` (same as `LIVEKIT_API_KEY`)
+- `DEPLOYMENT_LIVEKIT_API_SECRET` (same as `LIVEKIT_API_SECRET`)
+
+Until these are set, the app runs fine and the call API returns a clear
+"voice calling is not configured" error.

--- a/4-livekit/main.tf
+++ b/4-livekit/main.tf
@@ -1,0 +1,230 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+
+  backend "kubernetes" {
+    config_path   = "~/.kube/config"
+    secret_suffix = "livekit"
+  }
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+locals {
+  signaling_host = "livekit.${var.base_domain}"
+
+  # LiveKit server config. The SFU relays all media, so calls are never
+  # peer-to-peer. Signaling (7880) is fronted by traefik/TLS; media uses a
+  # single muxed TCP port (7881) and UDP port (7882) exposed via MetalLB.
+  livekit_yaml = yamlencode({
+    port = 7880
+    rtc = {
+      tcp_port        = 7881
+      udp_port        = 7882
+      use_external_ip = true
+    }
+    keys = {
+      (var.api_key) = var.api_secret
+    }
+  })
+}
+
+resource "kubernetes_namespace" "livekit" {
+  metadata {
+    name = "livekit"
+  }
+}
+
+# Config (including keys) as a Secret since it contains the API secret.
+resource "kubernetes_secret" "livekit" {
+  metadata {
+    name      = "livekit-config"
+    namespace = kubernetes_namespace.livekit.metadata[0].name
+  }
+
+  data = {
+    "livekit.yaml" = local.livekit_yaml
+  }
+}
+
+resource "kubernetes_deployment" "livekit" {
+  metadata {
+    name      = "livekit-server"
+    namespace = kubernetes_namespace.livekit.metadata[0].name
+  }
+
+  # Don't block apply on rollout health; media networking is environment
+  # specific and is verified out-of-band with real clients.
+  wait_for_rollout = false
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "livekit-server"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "livekit-server"
+        }
+        annotations = {
+          "config-hash" = sha1(local.livekit_yaml)
+        }
+      }
+
+      spec {
+        container {
+          name  = "livekit-server"
+          image = var.image
+          args  = ["--config", "/etc/livekit/livekit.yaml"]
+
+          port {
+            name           = "signaling"
+            container_port = 7880
+          }
+          port {
+            name           = "rtc-tcp"
+            container_port = 7881
+          }
+          port {
+            name           = "rtc-udp"
+            container_port = 7882
+            protocol       = "UDP"
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/etc/livekit"
+            read_only  = true
+          }
+        }
+
+        volume {
+          name = "config"
+          secret {
+            secret_name = kubernetes_secret.livekit.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+# Signaling service (ws) behind traefik + TLS.
+resource "kubernetes_service" "signaling" {
+  metadata {
+    name      = "livekit-signaling"
+    namespace = kubernetes_namespace.livekit.metadata[0].name
+  }
+
+  spec {
+    selector = {
+      app = "livekit-server"
+    }
+    port {
+      name        = "signaling"
+      port        = 80
+      target_port = 7880
+    }
+    type = "ClusterIP"
+  }
+}
+
+# Media service (RTC) exposed directly on the LAN via MetalLB. Clients reach
+# the SFU here; this IP/ports must be reachable from where users connect (e.g.
+# port-forwarded on the router for internet clients).
+resource "kubernetes_service" "media" {
+  metadata {
+    name      = "livekit-media"
+    namespace = kubernetes_namespace.livekit.metadata[0].name
+  }
+
+  spec {
+    selector = {
+      app = "livekit-server"
+    }
+    port {
+      name        = "rtc-tcp"
+      port        = 7881
+      target_port = 7881
+      protocol    = "TCP"
+    }
+    port {
+      name        = "rtc-udp"
+      port        = 7882
+      target_port = 7882
+      protocol    = "UDP"
+    }
+    type = "LoadBalancer"
+  }
+}
+
+resource "kubernetes_ingress_v1" "signaling" {
+  metadata {
+    name      = "livekit-signaling"
+    namespace = kubernetes_namespace.livekit.metadata[0].name
+  }
+
+  spec {
+    ingress_class_name = "traefik"
+
+    tls {
+      hosts       = [local.signaling_host]
+      secret_name = "livekit-tls"
+    }
+
+    rule {
+      host = local.signaling_host
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = kubernetes_service.signaling.metadata[0].name
+              port {
+                number = 80
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "certificate" {
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "Certificate"
+    metadata = {
+      name      = "livekit-certificate"
+      namespace = kubernetes_namespace.livekit.metadata[0].name
+    }
+    spec = {
+      secretName  = "livekit-tls"
+      duration    = "2160h"
+      renewBefore = "360h"
+      dnsNames    = [local.signaling_host]
+      issuerRef = {
+        name = var.certificate_issuer
+        kind = "ClusterIssuer"
+      }
+    }
+  }
+}
+
+output "signaling_url" {
+  description = "Set this as LIVEKIT_URL for apps."
+  value       = "wss://${local.signaling_host}"
+}

--- a/4-livekit/variables.tf
+++ b/4-livekit/variables.tf
@@ -1,0 +1,28 @@
+variable "base_domain" {
+  description = "Base domain; LiveKit signaling is served at livekit.<base_domain>."
+  type        = string
+}
+
+variable "api_key" {
+  description = "LiveKit API key. Must match LIVEKIT_API_KEY used by apps."
+  type        = string
+  sensitive   = true
+}
+
+variable "api_secret" {
+  description = "LiveKit API secret. Must match LIVEKIT_API_SECRET used by apps."
+  type        = string
+  sensitive   = true
+}
+
+variable "certificate_issuer" {
+  description = "cert-manager ClusterIssuer for the signaling TLS certificate."
+  type        = string
+  default     = "letsencrypt-production"
+}
+
+variable "image" {
+  description = "LiveKit server image."
+  type        = string
+  default     = "livekit/livekit-server:v1.8.4"
+}


### PR DESCRIPTION
Adds a `4-livekit` OpenTofu module that deploys a self-hosted **LiveKit SFU** so the `relay` app can do 1:1 voice calls.

## Why SFU = no P2P
LiveKit is a Selective Forwarding Unit: every client sends/receives media to/from the server. There is no peer-to-peer media path, so **all call traffic is server-relayed** — exactly the security requirement.

## What it deploys
- `livekit` namespace + `livekit-server` Deployment (`wait_for_rollout=false` so media health never blocks the infra apply)
- Config incl. API key/secret as a mounted Secret
- Signaling at **`wss://livekit.<BASE_DOMAIN>`** via traefik + cert-manager
- RTC media via a **MetalLB LoadBalancer** (TCP 7881, UDP 7882, single muxed ports)
- New `deploy-infrastructure` step wired with `BASE_DOMAIN` + `LIVEKIT_API_KEY`/`LIVEKIT_API_SECRET`

## Manual setup required (see `4-livekit/README.md`)
- DNS: `livekit.<BASE_DOMAIN>` → traefik LB IP
- Port-forward **TCP 7881 + UDP 7882** to the `livekit-media` MetalLB IP for internet clients
- Add org secrets `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET`
- In the relay repo, set `DEPLOYMENT_LIVEKIT_URL` / `DEPLOYMENT_LIVEKIT_API_KEY` / `DEPLOYMENT_LIVEKIT_API_SECRET`

⚠️ Real-time WebRTC media is environment-specific and **not verified by CI** — test with two real browsers before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)