### PR TITLE
fix: don't fail PR teardown when tofu workspace is missing

### DIFF
--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -189,10 +189,7 @@ jobs:
         run: |
           environment="${{ needs.configure.outputs.environment }}"
           tofu init
-          if ! tofu workspace select "$environment" 2>/dev/null; then
-            echo "Workspace \"$environment\" does not exist; nothing to destroy."
-            exit 0
-          fi
+          tofu workspace select "$environment" || exit 0
           tofu apply -input=false -auto-approve -destroy
           tofu workspace select default
           tofu workspace delete "$environment"

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -187,9 +187,8 @@ jobs:
           TF_VAR_hostname: ${{ needs.configure.outputs.hostname }}
           TF_VAR_certificate_issuer: ${{ needs.configure.outputs.certificate_issuer }}
         run: |
-          environment="${{ needs.configure.outputs.environment }}"
           tofu init
-          tofu workspace select "$environment" || exit 0
+          tofu workspace select ${{ needs.configure.outputs.environment }} || exit 0
           tofu apply -input=false -auto-approve -destroy
           tofu workspace select default
-          tofu workspace delete "$environment"
+          tofu workspace delete ${{ needs.configure.outputs.environment }}

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -187,8 +187,12 @@ jobs:
           TF_VAR_hostname: ${{ needs.configure.outputs.hostname }}
           TF_VAR_certificate_issuer: ${{ needs.configure.outputs.certificate_issuer }}
         run: |
+          environment="${{ needs.configure.outputs.environment }}"
           tofu init
-          tofu workspace select ${{ needs.configure.outputs.environment }}
+          if ! tofu workspace select "$environment" 2>/dev/null; then
+            echo "Workspace \"$environment\" does not exist; nothing to destroy."
+            exit 0
+          fi
           tofu apply -input=false -auto-approve -destroy
           tofu workspace select default
-          tofu workspace delete ${{ needs.configure.outputs.environment }}
+          tofu workspace delete "$environment"


### PR DESCRIPTION
## Problem
Closing a PR does **not** tear down its preview environment, while merging a PR does.

## Root cause
The **Destroy PR Environment** job in `deployments.yaml` runs:

```bash
tofu workspace select pr-<n>
```

without `-or-create`. If the workspace doesn't exist, `tofu workspace select` exits `1` and fails the whole run before destroy ever happens.

A workspace is missing whenever a PR is closed but never had a (completed) deploy:
- PR closed/abandoned before its deploy ran or finished
- open-then-close race (deploy and destroy run concurrently)

Merged PRs almost always had a green deploy first → workspace exists → teardown works. That's why the failure looked specific to *closing* rather than *merging* — it's really "no workspace" vs "workspace exists".

Confirmed in run logs, e.g. rutgerpronk.com#96 close:
```
tofu workspace select pr-96
Workspace "pr-96" doesn't exist.
##[error]Process completed with exit code 1.
```

(Note: an earlier failure mode — the destroy job couldn't reach the cluster API — was already fixed by adding the Tailscale step to this job.)

## Fix
Guard the workspace select: if it doesn't exist, there's nothing to destroy, so log and `exit 0` instead of failing the run. The deploy path already uses `-or-create`, so this just makes teardown symmetric and idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)