### PR TITLE
feat: periodically clean up abandoned PR environments

### DIFF
--- a/.github/scripts/deployment/open-pull-requests.mjs
+++ b/.github/scripts/deployment/open-pull-requests.mjs
@@ -1,0 +1,45 @@
+// @ts-check
+
+/**
+ * @typedef {import('@actions/github').context} Context
+ * @typedef {ReturnType<import('@actions/github').getOctokit>} GitHub
+ * @typedef {typeof core} Core
+ */
+
+/**
+ * Lists the numbers of every open pull request in the current repository.
+ *
+ * Used by the scheduled cleanup job to decide which `pr-<number>` environments
+ * still belong to an open pull request. Any environment whose pull request is
+ * no longer open is considered abandoned and gets destroyed.
+ *
+ * @param {Object} params
+ * @param {GitHub} params.github
+ * @param {Context} params.context
+ * @param {Core} params.core
+ * @returns {Promise<number[]>}
+ */
+export default async function listOpenPullRequests({ github, context, core }) {
+  try {
+    const { owner, repo } = context.repo;
+
+    const pullRequests = await github.paginate(github.rest.pulls.list, {
+      owner,
+      repo,
+      state: "open",
+      per_page: 100,
+    });
+
+    const numbers = pullRequests.map((pullRequest) => pullRequest.number);
+
+    core.info(`Open pull requests: ${numbers.join(", ") || "(none)"}`);
+    core.setOutput("numbers", numbers.join(" "));
+
+    return numbers;
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(error.message);
+    }
+    throw error;
+  }
+}

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   configure:
+    # Configuration is derived from the pull request / tag that triggered the
+    # run. The scheduled cleanup has no such trigger and doesn't need it.
+    if: github.event_name != 'schedule'
     name: Generate Configuration
     runs-on: ubuntu-latest
     outputs:
@@ -192,3 +195,79 @@ jobs:
           tofu apply -input=false -auto-approve -destroy
           tofu workspace select default
           tofu workspace delete ${{ needs.configure.outputs.environment }}
+
+  cleanup-pr-environments:
+    # Runs on a schedule (configured by the caller) to garbage-collect PR
+    # environments whose pull request was abandoned, i.e. never closed/merged
+    # so the per-PR `destroy-pr-environment` job never fired.
+    if: github.event_name == 'schedule'
+    name: Cleanup Abandoned PR Environments
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout infrastructure repository
+        uses: actions/checkout@v4
+        with:
+          repository: Rutger505-Org/kubernetes-infrastructure
+          path: infrastructure
+
+      - name: List open pull requests
+        id: open_prs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { default: listOpenPullRequests } = await import('${{ github.workspace }}/infrastructure/.github/scripts/deployment/open-pull-requests.mjs');
+            return await listOpenPullRequests({ github, context, core });
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Setup Kubernetes
+        uses: ./infrastructure/.github/actions/setup-kubernetes
+        with:
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: OpenTofu Destroy Abandoned PR Environments
+        working-directory: ./deploy
+        env:
+          OPEN_PR_NUMBERS: ${{ steps.open_prs.outputs.numbers }}
+          # Only application_name matters for a destroy: it keys the backend
+          # state and the resource names. The other required variables are
+          # placeholders that satisfy validation while resources are torn down.
+          TF_VAR_application_name: ${{ vars.APPLICATION_NAME }}
+          TF_VAR_image: unused
+          TF_VAR_hostname: unused
+          TF_VAR_certificate_issuer: letsencrypt-staging
+        run: |
+          set -euo pipefail
+
+          tofu init
+
+          environments=$(tofu workspace list | sed 's/^[*]//' | tr -d ' ' | grep -E '^pr-[0-9]+$' || true)
+
+          if [ -z "$environments" ]; then
+            echo "No PR environments found."
+            exit 0
+          fi
+
+          for environment in $environments; do
+            number="${environment#pr-}"
+
+            if echo " $OPEN_PR_NUMBERS " | grep -q " $number "; then
+              echo "Keeping $environment (PR #$number is still open)."
+              continue
+            fi
+
+            echo "Destroying $environment (PR #$number is not open)."
+            tofu workspace select "$environment"
+            tofu apply -input=false -auto-approve -destroy
+            tofu workspace select default
+            tofu workspace delete "$environment"
+          done


### PR DESCRIPTION
Closes #13.

## Problem
PR environments are created on PR open and destroyed on PR close/merge. **Abandoned** PRs (opened, never closed/merged) never trigger the `destroy-pr-environment` job, so their environment lingers in the cluster forever.

## Solution
A new `cleanup-pr-environments` job in the reusable `deployments.yaml`, gated on the `schedule` event:

1. Lists every open PR in the caller repo (`open-pull-requests.mjs` via github-script).
2. Runs `tofu workspace list` and finds `pr-<n>` workspaces.
3. For each workspace whose PR number is **not** in the open set → `tofu apply -destroy` + delete the workspace.

It reuses the exact teardown path of the existing per-PR destroy job (Tailscale → setup-kubernetes → tofu), and runs in the caller-repo context, so the `pr-<n>` ↔ PR-number mapping is trivial and the default `GITHUB_TOKEN` already scopes to the right repo. Only `application_name` matters for a destroy (it keys the backend state); the other required vars are placeholders.

`configure` is now skipped on `schedule` (it derives config from the triggering PR/tag, which a scheduled run doesn't have); `build`/`deploy` skip via their dependency on it.

## Caller opt-in (follow-up, after this merges)
Each app repo that uses this workflow just adds a `schedule` trigger to its existing `ci.yaml` — no new files, no new job:

```yaml
on:
  # ...existing push/pull_request triggers...
  schedule:
    - cron: "0 5 * * 1" # Monday 05:00 UTC
```

The existing `deploy: uses: .../deployments.yaml@main` reference then runs only the cleanup job on schedule. To roll out: nextjs-template (so new repos inherit it), rutgerpronk.com, relay.

> Note: GitHub cron is **UTC**, so 05:00 UTC = 07:00 Europe/Amsterdam (06:00 in winter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)